### PR TITLE
Throw a specific exception when a license is expired

### DIFF
--- a/Rhino.Licensing.Tests/Can_generate_and_validate_key.cs
+++ b/Rhino.Licensing.Tests/Can_generate_and_validate_key.cs
@@ -55,6 +55,26 @@ namespace Rhino.Licensing.Tests
         }
 
         [Fact]
+        public void Throws_date_exception_when_license_is_expired()
+        {
+            var guid = Guid.NewGuid();
+            var generator = new LicenseGenerator(public_and_private);
+            var expiration = DateTime.Now.AddDays(-1);
+            var key = generator.Generate("Oren Eini", guid, expiration,
+                                         new Dictionary<string, string>
+                                         {
+                                            {"prof", "llb"},
+                                            {"reporting", "on"}
+                                         }, LicenseType.Trial);
+
+            var path = Path.GetTempFileName();
+            File.WriteAllText(path, key);
+
+            var validator = new LicenseValidator(public_only, path);
+            Assert.Throws<LicenseExpiredException>(() => validator.AssertValidLicense());
+        }
+
+        [Fact]
         public void Cannot_validate_hacked_license()
         {
             const string hackedLicense =

--- a/Rhino.Licensing.Tests/Can_use_subscription_license.cs
+++ b/Rhino.Licensing.Tests/Can_use_subscription_license.cs
@@ -74,7 +74,7 @@ namespace Rhino.Licensing.Tests
             File.WriteAllText(path, license);
 
 
-            Assert.Throws<LicenseNotFoundException>(() => new LicenseValidator(public_only, path)
+            Assert.Throws<LicenseExpiredException>(() => new LicenseValidator(public_only, path)
             {
                 SubscriptionEndpoint = "http://localhost/" + Guid.NewGuid()
             }.AssertValidLicense());
@@ -125,7 +125,7 @@ namespace Rhino.Licensing.Tests
 
             host.Open();
 
-            Assert.Throws<LicenseNotFoundException>(() => new LicenseValidator(public_only, path)
+            Assert.Throws<LicenseExpiredException>(() => new LicenseValidator(public_only, path)
             {
                 SubscriptionEndpoint = address
             }.AssertValidLicense());

--- a/Rhino.Licensing/AbstractLicenseValidator.cs
+++ b/Rhino.Licensing/AbstractLicenseValidator.cs
@@ -192,8 +192,9 @@ namespace Rhino.Licensing
 
                 if (result)
                     ValidateUsingNetworkTime();
-
-                return result;
+                else
+                    throw new LicenseExpiredException("Expiration Date : " + ExpirationDate);
+                return true;
             }
             catch (RhinoLicensingException)
             {

--- a/Rhino.Licensing/LicenseExpiredException.cs
+++ b/Rhino.Licensing/LicenseExpiredException.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Rhino.Licensing
+{
+    ///<summary>
+    /// Thrown when license is found but is past it's expiration date
+    ///</summary>
+    public class LicenseExpiredException : RhinoLicensingException
+    {
+        /// <summary>
+        /// Creates a new instance of <seealso cref="RhinoLicensingException"/>.
+        /// </summary>
+        public LicenseExpiredException()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of <seealso cref="RhinoLicensingException"/>.
+        /// </summary>
+        /// <param name="message">error message</param>
+        public LicenseExpiredException(string message) : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of <seealso cref="RhinoLicensingException"/>.
+        /// </summary>
+        /// <param name="message">error message</param>
+        /// <param name="inner">inner exception</param>
+        public LicenseExpiredException(string message, Exception inner) : base(message, inner)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of <seealso cref="RhinoLicensingException"/>.
+        /// </summary>
+        /// <param name="info">serialization information</param>
+        /// <param name="context">streaming context</param>
+        public LicenseExpiredException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/Rhino.Licensing/Rhino.Licensing.csproj
+++ b/Rhino.Licensing/Rhino.Licensing.csproj
@@ -78,6 +78,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AbstractLicenseValidator.cs" />
+    <Compile Include="LicenseExpiredException.cs" />
     <Compile Include="InvalidationType.cs" />
     <Compile Include="StringLicenseValidator.cs" />
     <Compile Include="FloatingLicenseNotAvialableException.cs" />


### PR DESCRIPTION
I needed to know when the license is expired, but the error was the same as if the licence wasn't found.

The change seemed minimal, so here it goes.
