### PR TITLE
Adding discovery ctor parameter to the derived validator classes

### DIFF
--- a/Rhino.Licensing/LicenseValidator.cs
+++ b/Rhino.Licensing/LicenseValidator.cs
@@ -17,8 +17,9 @@ namespace Rhino.Licensing
         /// </summary>
         /// <param name="publicKey">public key</param>
         /// <param name="licensePath">path to license file</param>
-        public LicenseValidator(string publicKey, string licensePath)
-            : base(publicKey)
+        /// /// <param name="enableDiscovery">Whether to enable the client discovery server to detect duplicate licenses used on the same network.</param>
+        public LicenseValidator(string publicKey, string licensePath, bool enableDiscovery = true)
+            : base(publicKey, enableDiscovery)
         {
             this.licensePath = licensePath;
         }

--- a/Rhino.Licensing/StringLicenseValidator.cs
+++ b/Rhino.Licensing/StringLicenseValidator.cs
@@ -10,8 +10,9 @@
         /// </summary>
         /// <param name="publicKey">public key</param>
         /// <param name="license">license content</param>
-        public StringLicenseValidator(string publicKey, string license)
-            : base(publicKey)
+        /// <param name="enableDiscovery">Whether to enable the client discovery server to detect duplicate licenses used on the same network.</param>
+        public StringLicenseValidator(string publicKey, string license, bool enableDiscovery = true)
+            : base(publicKey, enableDiscovery)
         {
             License = license;
         }


### PR DESCRIPTION
`AbstractLicenseValidator` has an optional constructor argument that controls discovery. The `DiscoveryEnabled` property is protected, so the only way to alter it from the default (true) is to derive a new custom validator class.

I've added this constructor argument to the derived LicenseValidator and StringLicenseValidator so that discovery can be controlled without deriving an entirely new class.
